### PR TITLE
fix(remove libxml-ruby from defaults)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     opensrs (0.3.4)
-      libxml-ruby
 
 GEM
   remote: https://rubygems.org/
@@ -45,6 +44,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.7)
+  libxml-ruby
   nokogiri
   opensrs!
   rake (~> 10.0)

--- a/lib/opensrs.rb
+++ b/lib/opensrs.rb
@@ -1,5 +1,4 @@
 require File.dirname(__FILE__) + '/opensrs/xml_processor'
-require File.dirname(__FILE__) + '/opensrs/xml_processor/libxml.rb'
 require File.dirname(__FILE__) + '/opensrs/server.rb'
 require File.dirname(__FILE__) + '/opensrs/response.rb'
 require File.dirname(__FILE__) + '/opensrs/version.rb'

--- a/lib/opensrs/server.rb
+++ b/lib/opensrs/server.rb
@@ -51,8 +51,6 @@ module OpenSRS
       @@xml_processor = OpenSRS::XmlProcessor.const_get("#{name.to_s.capitalize}")
     end
 
-    OpenSRS::Server.xml_processor = :libxml
-
     private
 
     def headers(request)

--- a/opensrs.gemspec
+++ b/opensrs.gemspec
@@ -22,8 +22,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "libxml-ruby", ">= 0"
-
+  spec.add_development_dependency "libxml-ruby", ">= 0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 2.0"

--- a/spec/opensrs/xml_processor/libxml_spec.rb
+++ b/spec/opensrs/xml_processor/libxml_spec.rb
@@ -24,7 +24,7 @@ describe OpenSRS::XmlProcessor::Libxml do
       end
 
       it "has 3 children all called <item>" do
-        @e.should have(3).children
+        expect(@e.children.size).to eq(3)
         @e.children[0].name.should == "item"
         @e.children[1].name.should == "item"
         @e.children[2].name.should == "item"
@@ -51,7 +51,7 @@ describe OpenSRS::XmlProcessor::Libxml do
       end
 
       it "has an <item> child with the right key" do
-        @e.should have(1).children
+        expect(@e.children.size).to eq(1)
         @e.children[0].name.should == 'item'
         @e.children[0].attributes["key"].should == 'name'
       end
@@ -71,16 +71,16 @@ describe OpenSRS::XmlProcessor::Libxml do
       end
 
       it "has an <item> child with the correct children" do
-        @e.should have(1).children
+        expect(@e.children.size).to eq(1)
         suggestion = @e.children[0]
         suggestion.name.should == 'item'
         suggestion.attributes["key"].should == 'suggestion'
 
-        suggestion.should have(1).children
+        expect(suggestion.children.size).to eq(1)
         dt_assoc = suggestion.children[0]
         dt_assoc.name.should == 'dt_assoc'
 
-        dt_assoc.should have(1).children
+        expect(dt_assoc.children.size).to eq(1)
         maximum = dt_assoc.children[0]
         maximum.name.should == 'item'
         maximum.attributes["key"].should == 'maximum'

--- a/spec/opensrs/xml_processor/nokogiri_spec.rb
+++ b/spec/opensrs/xml_processor/nokogiri_spec.rb
@@ -1,3 +1,4 @@
+require_relative '../../../lib/opensrs/xml_processor/nokogiri'
 require 'date'
 
 class OrderedHash < Hash
@@ -27,7 +28,7 @@ describe OpenSRS::XmlProcessor::Nokogiri do
       it { @e.should be_an_instance_of(::Nokogiri::XML::Element) }
       it { @e.name.should eql('dt_array') }
 
-      it { @e.should have(3).children }
+      it { expect(@e.children.size).to eq(3) }
       it { @e.children[0].name.should eql("item") }
       it { @e.children[1].name.should eql("item") }
       it { @e.children[2].name.should eql("item") }
@@ -45,7 +46,7 @@ describe OpenSRS::XmlProcessor::Nokogiri do
       it { @e.should be_an_instance_of(::Nokogiri::XML::Element) }
       it { @e.name.should eql('dt_assoc') }
 
-      it { @e.should have(1).children }
+      it { expect(@e.children.size).to eq(1) }
       it { @e.children[0].name.should eql('item') }
       it { @e.children[0].attributes["key"].value.should eql('name') }
     end
@@ -60,7 +61,7 @@ describe OpenSRS::XmlProcessor::Nokogiri do
       it { @e.should be_an_instance_of(::Nokogiri::XML::Element) }
       it { @e.name.should eql('dt_assoc') }
 
-      it { @e.should have(1).children }
+      it { expect(@e.children.size).to eq(1) }
       it { @e.children[0].name.should eql('item') }
       it { @e.children[0].attributes["key"].value.should eql('name') }
     end
@@ -77,13 +78,13 @@ describe OpenSRS::XmlProcessor::Nokogiri do
       it { @e.name.should == 'dt_assoc' }
 
       context "<item> child" do
-        it { @e.should have(1).children }
+        it { expect(@e.children.size).to eq(1) }
         it { @suggestion.name.should eql('item') }
         it { @suggestion.attributes["key"].value.should eql('suggestion') }
       end
 
       context "suggesion children" do
-        it { @suggestion.should have(1).children }
+        it { expect(@suggestion.children.size).to eq(1) }
         it { @dt_assoc.name.should eql('dt_assoc') }
       end
 
@@ -91,7 +92,7 @@ describe OpenSRS::XmlProcessor::Nokogiri do
         before(:each) do
           @maximum = @dt_assoc.children[0]
         end
-        it { @dt_assoc.should have(1).children }
+        it { expect(@dt_assoc.children.size).to eq(1) }
         it { @maximum.name.should eql('item') }
         it { @maximum.attributes["key"].value.should eql('maximum') }
       end


### PR DESCRIPTION
## What? Why?

libxml is old, deprecated and dangerous. Remove it as a default dependency
## How was it tested

with rspec
## Check List
- [ ] PR contains unit tests
- [ ] PR contains integration tests (if suitable)
- [x] PR is squashed into one commit per logical change
## Message to support team

review: @dfguo 
cc: @danielglh @ming-relax 
